### PR TITLE
Made the github tracker look nicer

### DIFF
--- a/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
+++ b/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
@@ -9,49 +9,49 @@ import net.dv8tion.jda.core.EmbedBuilder;
 
 public class GithubListener implements EventListener<PushEvent> {
 
-	@Override
-	public void handle(PushEvent e) {
-		if (!FlareBot.getInstance().isReady())
-			return;
-		EmbedBuilder eb = MessageUtils.getEmbed();
-		eb.setAuthor(e.getSender().getLogin(), e.getSender().getProfile(), e.getSender().getAvatarUrl());
-		for (Commit commit : e.getCommits()) {
-			eb.addField("Commit:", "[" + 
-			commit.getId().substring(0, 7) + "](" + 
-			commit.getUrl() + ")\n Branch `" + 
-			e.getRef().substring(e.getRef().lastIndexOf('/') + 1) + "` " + "```" + 
-			commit.getMessage() + "```", false);
+    @Override
+    public void handle(PushEvent e) {
+        if (!FlareBot.getInstance().isReady())
+            return;
+        EmbedBuilder eb = MessageUtils.getEmbed();
+        eb.setAuthor(e.getSender().getLogin(), e.getSender().getProfile(), e.getSender().getAvatarUrl());
+        for (Commit commit : e.getCommits()) {
+            eb.addField("Commit:", "[" +
+                    commit.getId().substring(0, 7) + "](" +
+                    commit.getUrl() + ")\n Branch `" +
+                    e.getRef().substring(e.getRef().lastIndexOf('/') + 1) + "` " + "```" +
+                    commit.getMessage() + "```", false);
 
-			if (commit.getAdded().length > 0) {
-				StringBuilder sb = new StringBuilder();
-				sb.append("```Markdown\n");
-				for (String file : commit.getAdded()) {
-					sb.append("* " + file + "\n\n");
-				}
-				String added = sb.toString() + "```";
-				eb.addField("Added files", added, false);
-			}
+            if (commit.getAdded().length > 0) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("```Markdown\n");
+                for (String file : commit.getAdded()) {
+                    sb.append("* " + file + "\n\n");
+                }
+                String added = sb.toString() + "```";
+                eb.addField("Added files", added, false);
+            }
 
-			if (commit.getRemoved().length > 0) {
-				StringBuilder sb = new StringBuilder();
-				sb.append("```Markdown\n");
-				for (String file : commit.getRemoved()) {
-					sb.append("* " + file + "\n\n");
-				}
-				String removed = sb.toString() + "```";
-				eb.addField("Removed files", removed, false);
-			}
-			
-			if (commit.getModified().length > 0) {
-				StringBuilder sb = new StringBuilder();
-				sb.append("```Markdown\n");
-				for (String file : commit.getModified()) {
-					sb.append("* " + file + "\n\n");
-				}
-				String modified = sb.toString() + "```";
-				eb.addField("Modified files", modified, false);
-			}
-		}
-		FlareBot.getInstance().getChannelByID("229236239201468417").sendMessage(eb.build()).queue();
-	}
+            if (commit.getRemoved().length > 0) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("```Markdown\n");
+                for (String file : commit.getRemoved()) {
+                    sb.append("* " + file + "\n\n");
+                }
+                String removed = sb.toString() + "```";
+                eb.addField("Removed files", removed, false);
+            }
+
+            if (commit.getModified().length > 0) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("```Markdown\n");
+                for (String file : commit.getModified()) {
+                    sb.append("* " + file + "\n\n");
+                }
+                String modified = sb.toString() + "```";
+                eb.addField("Modified files", modified, false);
+            }
+        }
+        FlareBot.getInstance().getChannelByID("229236239201468417").sendMessage(eb.build()).queue();
+    }
 }

--- a/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
+++ b/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
@@ -16,7 +16,7 @@ public class GithubListener implements EventListener<PushEvent> {
         EmbedBuilder eb = MessageUtils.getEmbed();
         eb.setAuthor(e.getSender().getLogin(), e.getSender().getProfile(), e.getSender().getAvatarUrl());
         for (Commit commit : e.getCommits()) {
-			eb.addField("Commit:","[" + commit.getId().substring(0, 7) + "](" + commit.getUrl() + ")" + "```" + commit.getMessage() + "```", false);
+        	eb.addField("Commit:","[" + commit.getId().substring(0, 7) + "](" + commit.getUrl() + ")\n Branch `" + e.getRef().substring(e.getRef().lastIndexOf('/') + 1) + "` " + "```" + commit.getMessage() + "```", false);
         	
         	if(commit.getAdded().length > 0){
                 StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
+++ b/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
@@ -9,45 +9,49 @@ import net.dv8tion.jda.core.EmbedBuilder;
 
 public class GithubListener implements EventListener<PushEvent> {
 
-    @Override
-    public void handle(PushEvent e) {
-        if (!FlareBot.getInstance().isReady())
-            return;
-        EmbedBuilder eb = MessageUtils.getEmbed();
-        eb.setAuthor(e.getSender().getLogin(), e.getSender().getProfile(), e.getSender().getAvatarUrl());
-        for (Commit commit : e.getCommits()) {
-        	eb.addField("Commit:","[" + commit.getId().substring(0, 7) + "](" + commit.getUrl() + ")\n Branch `" + e.getRef().substring(e.getRef().lastIndexOf('/') + 1) + "` " + "```" + commit.getMessage() + "```", false);
-        	
-        	if(commit.getAdded().length > 0){
-                StringBuilder sb = new StringBuilder();
-                sb.append("```Markdown\n");
-				for(String file: commit.getAdded()){
+	@Override
+	public void handle(PushEvent e) {
+		if (!FlareBot.getInstance().isReady())
+			return;
+		EmbedBuilder eb = MessageUtils.getEmbed();
+		eb.setAuthor(e.getSender().getLogin(), e.getSender().getProfile(), e.getSender().getAvatarUrl());
+		for (Commit commit : e.getCommits()) {
+			eb.addField("Commit:", "[" + 
+			commit.getId().substring(0, 7) + "](" + 
+			commit.getUrl() + ")\n Branch `" + 
+			e.getRef().substring(e.getRef().lastIndexOf('/') + 1) + "` " + "```" + 
+			commit.getMessage() + "```", false);
+
+			if (commit.getAdded().length > 0) {
+				StringBuilder sb = new StringBuilder();
+				sb.append("```Markdown\n");
+				for (String file : commit.getAdded()) {
 					sb.append("* " + file + "\n\n");
 				}
 				String added = sb.toString() + "```";
 				eb.addField("Added files", added, false);
 			}
-        	
-        	if(commit.getRemoved().length > 0){
-                StringBuilder sb = new StringBuilder();
-                sb.append("```Markdown\n");
-				for(String file: commit.getRemoved()){
+
+			if (commit.getRemoved().length > 0) {
+				StringBuilder sb = new StringBuilder();
+				sb.append("```Markdown\n");
+				for (String file : commit.getRemoved()) {
 					sb.append("* " + file + "\n\n");
 				}
 				String removed = sb.toString() + "```";
 				eb.addField("Removed files", removed, false);
 			}
-        	
-        	if(commit.getModified().length > 0){
-                StringBuilder sb = new StringBuilder();
-                sb.append("```Markdown\n");
-				for(String file: commit.getModified()){
+			
+			if (commit.getModified().length > 0) {
+				StringBuilder sb = new StringBuilder();
+				sb.append("```Markdown\n");
+				for (String file : commit.getModified()) {
 					sb.append("* " + file + "\n\n");
 				}
 				String modified = sb.toString() + "```";
 				eb.addField("Modified files", modified, false);
 			}
-        }
-        FlareBot.getInstance().getChannelByID("229236239201468417").sendMessage(eb.build()).queue();
-    }
+		}
+		FlareBot.getInstance().getChannelByID("229236239201468417").sendMessage(eb.build()).queue();
+	}
 }

--- a/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
+++ b/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
@@ -25,9 +25,17 @@ public class GithubListener implements EventListener<PushEvent> {
             if (commit.getAdded().length > 0) {
                 StringBuilder sb = new StringBuilder();
                 sb.append("```md\n");
+                int i = 1;
                 for (String file : commit.getAdded()) {
-                    sb.append("* " + file + "\n\n");
+                    if (!(i++ >= 5)) {
+                        sb.append("* " + file + "\n\n");
+                    }
                 }
+
+                if (commit.getRemoved().length >= 5) {
+                    sb.append("...");
+                }
+
                 String added = sb.toString() + "```";
                 eb.addField("Added files", added, false);
             }
@@ -35,9 +43,17 @@ public class GithubListener implements EventListener<PushEvent> {
             if (commit.getRemoved().length > 0) {
                 StringBuilder sb = new StringBuilder();
                 sb.append("```md\n");
+                int i = 1;
                 for (String file : commit.getRemoved()) {
-                    sb.append("* " + file + "\n\n");
+                    if (!(i++ >= 5)) {
+                        sb.append("* " + file + "\n\n");
+                    }
                 }
+
+                if (commit.getRemoved().length >= 5) {
+                    sb.append("...");
+                }
+
                 String removed = sb.toString() + "```";
                 eb.addField("Removed files", removed, false);
             }
@@ -45,9 +61,17 @@ public class GithubListener implements EventListener<PushEvent> {
             if (commit.getModified().length > 0) {
                 StringBuilder sb = new StringBuilder();
                 sb.append("```md\n");
+                int i = 1;
                 for (String file : commit.getModified()) {
-                    sb.append("* " + file + "\n\n");
+                    if (!(i++ >= 5)) {
+                        sb.append("* " + file + "\n\n");
+                    }
                 }
+
+                if (commit.getModified().length >= 5) {
+                    sb.append("...");
+                }
+
                 String modified = sb.toString() + "```";
                 eb.addField("Modified files", modified, false);
             }

--- a/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
+++ b/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
@@ -24,7 +24,7 @@ public class GithubListener implements EventListener<PushEvent> {
 
             if (commit.getAdded().length > 0) {
                 StringBuilder sb = new StringBuilder();
-                sb.append("```Markdown\n");
+                sb.append("```md\n");
                 for (String file : commit.getAdded()) {
                     sb.append("* " + file + "\n\n");
                 }
@@ -34,7 +34,7 @@ public class GithubListener implements EventListener<PushEvent> {
 
             if (commit.getRemoved().length > 0) {
                 StringBuilder sb = new StringBuilder();
-                sb.append("```Markdown\n");
+                sb.append("```md\n");
                 for (String file : commit.getRemoved()) {
                     sb.append("* " + file + "\n\n");
                 }
@@ -44,7 +44,7 @@ public class GithubListener implements EventListener<PushEvent> {
 
             if (commit.getModified().length > 0) {
                 StringBuilder sb = new StringBuilder();
-                sb.append("```Markdown\n");
+                sb.append("```md\n");
                 for (String file : commit.getModified()) {
                     sb.append("* " + file + "\n\n");
                 }

--- a/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
+++ b/src/main/java/com/bwfcwalshy/flarebot/github/GithubListener.java
@@ -15,16 +15,39 @@ public class GithubListener implements EventListener<PushEvent> {
             return;
         EmbedBuilder eb = MessageUtils.getEmbed();
         eb.setAuthor(e.getSender().getLogin(), e.getSender().getProfile(), e.getSender().getAvatarUrl());
-        StringBuilder sb = new StringBuilder();
         for (Commit commit : e.getCommits()) {
-            sb.append(String.format("`%s` in `%s` - [`%s`](%s) %s\n",
-                    commit.getAuthor().getName(),
-                    e.getRef().substring(e.getRef().lastIndexOf('/') + 1),
-                    commit.getId().substring(0, 7),
-                    commit.getUrl(),
-                    commit.getMessage()));
+			eb.addField("Commit:","[" + commit.getId().substring(0, 7) + "](" + commit.getUrl() + ")" + "```" + commit.getMessage() + "```", false);
+        	
+        	if(commit.getAdded().length > 0){
+                StringBuilder sb = new StringBuilder();
+                sb.append("```Markdown\n");
+				for(String file: commit.getAdded()){
+					sb.append("* " + file + "\n\n");
+				}
+				String added = sb.toString() + "```";
+				eb.addField("Added files", added, false);
+			}
+        	
+        	if(commit.getRemoved().length > 0){
+                StringBuilder sb = new StringBuilder();
+                sb.append("```Markdown\n");
+				for(String file: commit.getRemoved()){
+					sb.append("* " + file + "\n\n");
+				}
+				String removed = sb.toString() + "```";
+				eb.addField("Removed files", removed, false);
+			}
+        	
+        	if(commit.getModified().length > 0){
+                StringBuilder sb = new StringBuilder();
+                sb.append("```Markdown\n");
+				for(String file: commit.getModified()){
+					sb.append("* " + file + "\n\n");
+				}
+				String modified = sb.toString() + "```";
+				eb.addField("Modified files", modified, false);
+			}
         }
-        eb.setDescription(sb.toString());
         FlareBot.getInstance().getChannelByID("229236239201468417").sendMessage(eb.build()).queue();
     }
 }


### PR DESCRIPTION
Separated out commits and commit messages more.

Added added, removed, and modified files.

Example:
![flaregithub](https://cloud.githubusercontent.com/assets/10491247/23415183/07a18e70-fda4-11e6-87ed-42ad24077780.PNG)

The author is still the same as it was before.