### PR TITLE
Modlog fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>stream.flarebot</groupId>
     <artifactId>flarebot</artifactId>
-    <version>4.1.0.1</version>
+    <version>4.1.0.2</version>
 
     <repositories>
         <repository> <!-- This repo fixes issues with transitive dependencies -->

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/LockChatCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/LockChatCommand.java
@@ -35,7 +35,7 @@ public class LockChatCommand implements Command {
         }
         if (tc.getPermissionOverride(guild.getGuild().getPublicRole()) == null) {
             tc.createPermissionOverride(guild.getGuild().getPublicRole()).setDeny(Permission.MESSAGE_WRITE).queue();
-            tc.createPermissionOverride(guild.getGuild().getSelfMember()).setAllow(Permission.MESSAGE_WRITE).queue();
+            tc.createPermissionOverride(guild.getGuild().getSelfMember()).setAllow(Permission.MESSAGE_WRITE, Permission.MESSAGE_READ).queue();
             channel.sendMessage(new EmbedBuilder().setColor(ColorUtils.RED)
                     .setDescription("The chat has been locked by a staff member!" + (reason != null ? "\nReason: " + reason : ""))
                     .build()).queue();
@@ -48,7 +48,7 @@ public class LockChatCommand implements Command {
                     .build()).queue();
         } else {
             tc.getPermissionOverride(guild.getGuild().getPublicRole()).getManager().deny(Permission.MESSAGE_WRITE).queue();
-            tc.createPermissionOverride(guild.getGuild().getSelfMember()).setAllow(Permission.MESSAGE_WRITE).queue();
+            tc.createPermissionOverride(guild.getGuild().getSelfMember()).setAllow(Permission.MESSAGE_WRITE, Permission.MESSAGE_READ).queue();
             channel.sendMessage(new EmbedBuilder().setColor(ColorUtils.RED)
                     .setDescription("The chat has been locked by a staff member!" + (reason != null ? "\nReason: " + reason : ""))
                     .build()).queue();

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/LockChatCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/LockChatCommand.java
@@ -35,17 +35,20 @@ public class LockChatCommand implements Command {
         }
         if (tc.getPermissionOverride(guild.getGuild().getPublicRole()) == null) {
             tc.createPermissionOverride(guild.getGuild().getPublicRole()).setDeny(Permission.MESSAGE_WRITE).queue();
+            tc.createPermissionOverride(guild.getGuild().getSelfMember()).setAllow(Permission.MESSAGE_WRITE).queue();
             channel.sendMessage(new EmbedBuilder().setColor(ColorUtils.RED)
                     .setDescription("The chat has been locked by a staff member!" + (reason != null ? "\nReason: " + reason : ""))
                     .build()).queue();
         }
         if (tc.getPermissionOverride(guild.getGuild().getPublicRole()).getDenied().contains(Permission.MESSAGE_WRITE)) {
             tc.getPermissionOverride(guild.getGuild().getPublicRole()).getManager().grant(Permission.MESSAGE_WRITE).queue();
+            tc.getPermissionOverride(guild.getGuild().getSelfMember()).delete().queue();
             channel.sendMessage(new EmbedBuilder().setColor(ColorUtils.GREEN)
                     .setDescription("The chat has been unlocked!" + (reason != null ? "\nReason: " + reason : ""))
                     .build()).queue();
         } else {
             tc.getPermissionOverride(guild.getGuild().getPublicRole()).getManager().deny(Permission.MESSAGE_WRITE).queue();
+            tc.createPermissionOverride(guild.getGuild().getSelfMember()).setAllow(Permission.MESSAGE_WRITE).queue();
             channel.sendMessage(new EmbedBuilder().setColor(ColorUtils.RED)
                     .setDescription("The chat has been locked by a staff member!" + (reason != null ? "\nReason: " + reason : ""))
                     .build()).queue();

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
@@ -81,6 +81,7 @@ public class ModlogCommand implements Command {
                 if (args.length == 2) {
                     page = GeneralUtils.getInt(args[1], 1);
                 }
+                
                 listEvents(channel, page, guild, false);
                 return;
             }
@@ -279,8 +280,10 @@ public class ModlogCommand implements Command {
                 if (groupKey == null || groupKey.isEmpty())
                      groupKey = split[0];
                         
-                if (!groupKey.equals(split[0]))
-                     sb.append('\n');
+                if (!groupKey.equals(split[0])) {
+                    sb.append('\n');
+                    groupKey = split[0];
+                }
                         
                 sb.append("`").append(modlogEvent.getTitle()).append("` - ").append(modlogEvent.getDescription()).append('\n');
             }

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
@@ -272,7 +272,6 @@ public class ModlogCommand implements Command {
             return;
         } else {
             StringBuilder sb = new StringBuilder();
-            Map<String, List<ModlogEvent>> groups = new HashMap<>();
             String groupKey = null;
             for (ModlogEvent modlogEvent : ModlogEvent.events.subList(start, end)) {
                 String name = modlogEvent.getName();

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
@@ -254,7 +254,7 @@ public class ModlogCommand implements Command {
         int pageSize = 15;
         List<ModlogEvent> events;
         if (enabledEvents)
-            events = wrapper.getModeration().getEnabledActions().map(ModlogAction::getEvent).collect(Collectors.toList());
+            events = wrapper.getModeration().getEnabledActions().map(action -> action.getEvent()).collect(Collectors.toList());
         else
             events = ModlogEvent.events;
         int pages = events.size() < pageSize ? 1 : (events.size() / pageSize)

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
@@ -81,13 +81,8 @@ public class ModlogCommand implements Command {
                 if (args.length == 2) {
                     page = GeneralUtils.getInt(args[1], 1);
                 }
-<<<<<<< HEAD
                 listEvents(channel, page, guild, false);
                 return;
-=======
-                
-                listEvents(channel, page, guild, false);
->>>>>>> 87715b7e7bbccf90dfbb6eaa6d8d025e084d0a23
             }
         }
         if (args.length >= 2) {

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
@@ -82,15 +82,15 @@ public class ModlogCommand implements Command {
                     page = GeneralUtils.getInt(args[1], 1);
                 }
                 int pageSize = 15;
-                Set<ModlogAction> actions = guild.getModeration().getEnabledActions();
-                int pages = actions.size() < pageSize ? 1 : (actions.size() / pageSize)
-                        + (actions.size() % pageSize != 0 ? 1 : 0);
+                List<ModlogEvent> events = ModlogEvent.events;
+                int pages = events.size() < pageSize ? 1 : (events.size() / pageSize)
+                        + (events.size() % pageSize != 0 ? 1 : 0);
 
                 int start;
                 int end;
 
                 start = pageSize * (page - 1);
-                end = Math.min(start + pageSize, actions.size());
+                end = Math.min(start + pageSize, events.size());
 
                 if (page > pages || page < 0) {
                     MessageUtils.sendErrorMessage("That page doesn't exist. Current page count: " + pages, channel);
@@ -98,29 +98,17 @@ public class ModlogCommand implements Command {
                 } else {
                     StringBuilder sb = new StringBuilder();
                     Map<String, List<ModlogEvent>> groups = new HashMap<>();
+                    String groupKey;
                     for (ModlogEvent modlogEvent : ModlogEvent.events.subList(start, end)) {
                         String name = modlogEvent.getName();
                         String[] split = name.split(" ");
-                        String groupKey = split[0];
-                        if (groups.containsKey(groupKey)) {
-                            List<ModlogEvent> group = groups.get(groupKey);
-                            group.add(modlogEvent);
-                            groups.put(groupKey, group);
-                        } else {
-                            List<ModlogEvent> group = new ArrayList<>();
-                            group.add(modlogEvent);
-                            groups.put(groupKey, group);
-                        }
-                    }
-
-                    Iterator<Map.Entry<String, List<ModlogEvent>>> it = groups.entrySet().iterator();
-                    while (it.hasNext()) {
-                        Map.Entry<String, List<ModlogEvent>> pair = it.next();
-                        for (ModlogEvent event : pair.getValue()) {
-                            sb.append("`").append(event.getTitle()).append("` - ").append(event.getDescription()).append("\n");
-                        }
-                        sb.append("\n");
-                        it.remove();
+                        if(groupKey == null || groupKey.isEmpty())
+                            groupKey = split[0];
+                        
+                        if(!groupKey.equals(split[0]))
+                            sb.append('\n');
+                        
+                        sb.append("`").append(event.getTitle()).append("` - ").append(event.getDescription()).append('\n');
                     }
                     sb.append("`Default` - Is for all the normal default events\n");
                     sb.append("`All` - Is for targeting all events");

--- a/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/moderation/mod/ModlogCommand.java
@@ -81,8 +81,8 @@ public class ModlogCommand implements Command {
                 if (args.length == 2) {
                     page = GeneralUtils.getInt(args[1], 1);
                 }
-                
-                listFeatures(channel, page, guild, false);
+                listEvents(channel, page, guild, false);
+                return;
             }
         }
         if (args.length >= 2) {
@@ -254,7 +254,7 @@ public class ModlogCommand implements Command {
         int pageSize = 15;
         List<ModlogEvent> events;
         if (enabledEvents)
-            events = wrapper.getModeration().getEnabledActions().map(action -> action.getEvent()).collect(Collectors.toList());
+            events = wrapper.getModeration().getEnabledActions().stream().map(action -> action.getEvent()).collect(Collectors.toList());
         else
             events = ModlogEvent.events;
         int pages = events.size() < pageSize ? 1 : (events.size() / pageSize)
@@ -272,7 +272,7 @@ public class ModlogCommand implements Command {
         } else {
             StringBuilder sb = new StringBuilder();
             Map<String, List<ModlogEvent>> groups = new HashMap<>();
-            String groupKey;
+            String groupKey = null;
             for (ModlogEvent modlogEvent : ModlogEvent.events.subList(start, end)) {
                 String name = modlogEvent.getName();
                 String[] split = name.split(" ");
@@ -282,7 +282,7 @@ public class ModlogCommand implements Command {
                 if (!groupKey.equals(split[0]))
                      sb.append('\n');
                         
-                sb.append("`").append(event.getTitle()).append("` - ").append(event.getDescription()).append('\n');
+                sb.append("`").append(modlogEvent.getTitle()).append("` - ").append(modlogEvent.getDescription()).append('\n');
             }
             if (!enabledEvents) {
                 sb.append("`Default` - Is for all the normal default events\n");

--- a/src/main/java/stream/flarebot/flarebot/commands/useful/TagsCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/useful/TagsCommand.java
@@ -72,7 +72,8 @@ public class TagsCommand implements Command {
                 }
                 if (guild.getTags().containsKey(args[1].toLowerCase())) {
                     MessageUtils.sendErrorMessage("This tag already exists!", channel);
-                    return;}
+                    return;
+                }
 
                 guild.getTags().put(args[1].toLowerCase(), MessageUtils.getMessage(args, 2));
                 MessageUtils.sendSuccessMessage("You successfully added the tag `" + args[1] + "`!", channel,

--- a/src/main/java/stream/flarebot/flarebot/commands/useful/TagsCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/useful/TagsCommand.java
@@ -39,6 +39,10 @@ public class TagsCommand implements Command {
                         + "Usage: `{%}tags add " + args[1] + " <tag_message>`" +
                         "\n\nView the usage for variables you can use!", channel);
             } else if (args[0].equalsIgnoreCase("remove")) {
+                if (!getPermissions(channel).hasPermission(member, "flarebot.tags.admin")) {
+                    MessageUtils.sendErrorMessage("You need the permission `flarebot.tags.admin` to do this!", channel, sender);
+                    return;
+                }
                 if (guild.getTags().containsKey(args[1].toLowerCase())) {
                     guild.getTags().remove(args[1]);
                     MessageUtils.sendSuccessMessage("You successfully removed the tag `" + args[1] + "`!",
@@ -62,15 +66,22 @@ public class TagsCommand implements Command {
             }
         } else {
             if (args[0].equalsIgnoreCase("add")) {
-                if (guild.getTags().containsKey(args[1].toLowerCase())) {
-                    MessageUtils.sendErrorMessage("This tag already exists!", channel);
+                if (!getPermissions(channel).hasPermission(member, "flarebot.tags.admin")) {
+                    MessageUtils.sendErrorMessage("You need the permission `flarebot.tags.admin` to do this!", channel, sender);
                     return;
                 }
+                if (guild.getTags().containsKey(args[1].toLowerCase())) {
+                    MessageUtils.sendErrorMessage("This tag already exists!", channel);
+                    return;}
 
                 guild.getTags().put(args[1].toLowerCase(), MessageUtils.getMessage(args, 2));
                 MessageUtils.sendSuccessMessage("You successfully added the tag `" + args[1] + "`!", channel,
                         sender);
             } else if (args[0].equalsIgnoreCase("edit")) {
+                if (!getPermissions(channel).hasPermission(member, "flarebot.tags.admin")) {
+                    MessageUtils.sendErrorMessage("You need the permission `flarebot.tags.admin` to do this!", channel, sender);
+                    return;
+                }
                 if (!guild.getTags().containsKey(args[1].toLowerCase())) {
                     MessageUtils.sendErrorMessage("This tag doesn't exist!", channel);
                     return;

--- a/src/main/java/stream/flarebot/flarebot/mod/modlog/ModAction.java
+++ b/src/main/java/stream/flarebot/flarebot/mod/modlog/ModAction.java
@@ -13,7 +13,7 @@ public enum ModAction {
     MUTE(true, ModlogEvent.USER_MUTED),
     UNMUTE(false, ModlogEvent.USER_UNMUTED),
 
-    WARN(true, ModlogEvent.USER_WARN);
+    WARN(true, ModlogEvent.USER_WARNED);
 
     private boolean infraction;
     private ModlogEvent event;

--- a/src/main/java/stream/flarebot/flarebot/mod/modlog/ModAction.java
+++ b/src/main/java/stream/flarebot/flarebot/mod/modlog/ModAction.java
@@ -10,10 +10,10 @@ public enum ModAction {
     KICK(true, ModlogEvent.USER_KICKED),
 
     TEMP_MUTE(true, ModlogEvent.USER_TEMP_MUTED),
-    MUTE(true, ModlogEvent.USER_TEMP_MUTED),
-    UNMUTE(false, ModlogEvent.USER_TEMP_MUTED),
+    MUTE(true, ModlogEvent.USER_MUTED),
+    UNMUTE(false, ModlogEvent.USER_UNMUTED),
 
-    WARN(true, ModlogEvent.USER_TEMP_MUTED);
+    WARN(true, ModlogEvent.USER_WARN);
 
     private boolean infraction;
     private ModlogEvent event;


### PR DESCRIPTION
- [X] Completed PR - Has all features or fixes that it was meant to and isn't half done
- [X] Follows the style guide - Style guide found [here](https://github.com/FlareBot/FlareBot/blob/master/CONTRIBUTING.md)
- [X] All changes have been tested

## Fixed
* `_modlog features` should now show all the events again
* `_modlog enable/disable <x>` will no longer list on invalid events, this was done due to the amount of events and the fact it didn't look too good.
* Some modlog events would post USER_TEMP_MUTED instead of their actual event, this is now corrected.
* FlareBot will no longer lock himself out of a locked chat. `_lockchat` should now always work!
* Tags now properly have sub-perms! Use `flarebot.tags.admin` for things like add, remove and edit!