### PR TITLE
Fix/commands

### DIFF
--- a/src/main/java/stream/flarebot/flarebot/Events.java
+++ b/src/main/java/stream/flarebot/flarebot/Events.java
@@ -483,8 +483,6 @@ public class Events extends ListenerAdapter {
         }
     }
     
-    
-
     public int getCommandCount() {
         return commandCounter.get();
     }

--- a/src/main/java/stream/flarebot/flarebot/Events.java
+++ b/src/main/java/stream/flarebot/flarebot/Events.java
@@ -359,8 +359,7 @@ public class Events extends ListenerAdapter {
             }
         }
         handleSpamDetection(event, guild);
-        if (cmd.getType() == CommandType.SECRET && !PerGuildPermissions.isCreator(event.getAuthor()) && !(flareBot.isTestBot()
-                && PerGuildPermissions.isContributor(event.getAuthor()))) {
+        if (GeneralUtils.canRunCommand(cmd, event.getAuthor())) {
             GeneralUtils.sendImage("https://flarebot.stream/img/trap.jpg", "trap.jpg", event.getAuthor());
             flareBot.logEG("It's a trap", cmd, guild.getGuild(), event.getAuthor());
             return;
@@ -483,6 +482,8 @@ public class Events extends ListenerAdapter {
             spamMap.put(event.getGuild().getId(), 1);
         }
     }
+    
+    
 
     public int getCommandCount() {
         return commandCounter.get();

--- a/src/main/java/stream/flarebot/flarebot/commands/Command.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/Command.java
@@ -30,7 +30,7 @@ public interface Command {
     }
 
     default String getPermission() {
-        return getType() == CommandType.SECRET ? null : "flarebot." + getCommand();
+        return getType().isInternal() ? null : "flarebot." + getCommand();
     }
 
     default EnumSet<Permission> getDiscordPermission() {
@@ -46,8 +46,7 @@ public interface Command {
     }
 
     default boolean isDefaultPermission() {
-        return (getPermission() != null && getType() != CommandType.SECRET && getType() != CommandType.INTERNAL
-                && getType() != CommandType.MODERATION);
+        return (getPermission() != null && !getType().isInternal();
     }
 
     default boolean deleteMessage() {

--- a/src/main/java/stream/flarebot/flarebot/commands/Command.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/Command.java
@@ -46,7 +46,7 @@ public interface Command {
     }
 
     default boolean isDefaultPermission() {
-        return (getPermission() != null && !getType().isInternal();
+        return getPermission() != null && !getType().isInternal();
     }
 
     default boolean deleteMessage() {

--- a/src/main/java/stream/flarebot/flarebot/commands/CommandType.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/CommandType.java
@@ -16,6 +16,7 @@ public enum CommandType {
     RANDOM(false),
     INFORMATIONAL(false),
     SECRET(false, Constants.DEVELOPER_ID),
+    DEBUG(false, Constants.CONTRIBUTOR_ID),
     INTERNAL(false, Constants.STAFF_ID);
 
     private static final CommandType[] values = values();

--- a/src/main/java/stream/flarebot/flarebot/commands/CommandType.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/CommandType.java
@@ -3,6 +3,7 @@ package stream.flarebot.flarebot.commands;
 import stream.flarebot.flarebot.FlareBot;
 import stream.flarebot.flarebot.util.Constants;
 
+import java.util.Arrays;
 import java.util.Set;
 
 public enum CommandType {

--- a/src/main/java/stream/flarebot/flarebot/commands/CommandType.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/CommandType.java
@@ -37,6 +37,10 @@ public enum CommandType {
     public String toString() {
         return name().charAt(0) + name().substring(1).toLowerCase();
     }
+    
+    public boolean isInternal() {
+        return internalRoleId > 0;
+    }
 
     public static CommandType[] getTypes() {
         return defaultTypes;

--- a/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
@@ -19,12 +19,26 @@ public class CommandUsageCommand implements Command {
             MessageUtils.sendUsage(this, channel, sender, args);
         } else {
             Command c = FlareBot.getInstance().getCommand(args[0], sender);
-            if (c == null || (c.getType() == CommandType.SECRET && !PerGuildPermissions.isCreator(sender))) {
+            if (!canRunCommand(c, sender))
                 MessageUtils.sendErrorMessage("That is not a command!", channel);
             } else {
                 MessageUtils.sendUsage(c, channel, sender, new String[]{});
             }
         }
+    }
+    
+    private boolean canRunCommand(Command command, User user) {
+        if (command == null) return false;
+        
+        if (command.getType().isInternal()) {
+            Guild g = FlareBot.getInstance().getOfficialGuild();
+            
+            if (g.getMember(user) != null) {
+                return g.getMember(user).getRoles().contains(g.getRoleById(command.getType().getRoleId()));
+            } else
+                return false;
+        } else
+            return true;
     }
 
     @Override

--- a/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.User;
+import net.dv8tion.jda.core.entities.Guild;
 import stream.flarebot.flarebot.FlareBot;
 import stream.flarebot.flarebot.commands.Command;
 import stream.flarebot.flarebot.commands.CommandType;

--- a/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
@@ -11,6 +11,7 @@ import stream.flarebot.flarebot.commands.CommandType;
 import stream.flarebot.flarebot.objects.GuildWrapper;
 import stream.flarebot.flarebot.permissions.PerGuildPermissions;
 import stream.flarebot.flarebot.util.MessageUtils;
+import stream.flarebot.flarebot.util.GeneralUtils;
 
 public class CommandUsageCommand implements Command {
 
@@ -20,25 +21,11 @@ public class CommandUsageCommand implements Command {
             MessageUtils.sendUsage(this, channel, sender, args);
         } else {
             Command c = FlareBot.getInstance().getCommand(args[0], sender);
-            if (!canRunCommand(c, sender))
+            if (!GeneralUtils.canRunCommand(c, sender))
                 MessageUtils.sendErrorMessage("That is not a command!", channel);
             else
                 MessageUtils.sendUsage(c, channel, sender, new String[]{});
         }
-    }
-    
-    private boolean canRunCommand(Command command, User user) {
-        if (command == null) return false;
-        
-        if (command.getType().isInternal()) {
-            Guild g = FlareBot.getInstance().getOfficialGuild();
-            
-            if (g.getMember(user) != null)
-                return g.getMember(user).getRoles().contains(g.getRoleById(command.getType().getRoleId()));
-            else
-                return false;
-        } else
-            return true;
     }
 
     @Override

--- a/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/general/CommandUsageCommand.java
@@ -21,9 +21,8 @@ public class CommandUsageCommand implements Command {
             Command c = FlareBot.getInstance().getCommand(args[0], sender);
             if (!canRunCommand(c, sender))
                 MessageUtils.sendErrorMessage("That is not a command!", channel);
-            } else {
+            else
                 MessageUtils.sendUsage(c, channel, sender, new String[]{});
-            }
         }
     }
     
@@ -33,9 +32,9 @@ public class CommandUsageCommand implements Command {
         if (command.getType().isInternal()) {
             Guild g = FlareBot.getInstance().getOfficialGuild();
             
-            if (g.getMember(user) != null) {
+            if (g.getMember(user) != null)
                 return g.getMember(user).getRoles().contains(g.getRoleById(command.getType().getRoleId()));
-            } else
+            else
                 return false;
         } else
             return true;

--- a/src/main/java/stream/flarebot/flarebot/commands/secret/DebugCommand.java
+++ b/src/main/java/stream/flarebot/flarebot/commands/secret/DebugCommand.java
@@ -108,7 +108,7 @@ public class DebugCommand implements Command {
 
     @Override
     public CommandType getType() {
-        return CommandType.SECRET;
+        return CommandType.DEBUG;
     }
 
     private String getMB(long bytes) {

--- a/src/main/java/stream/flarebot/flarebot/util/GeneralUtils.java
+++ b/src/main/java/stream/flarebot/flarebot/util/GeneralUtils.java
@@ -692,4 +692,24 @@ public class GeneralUtils {
         return period.toStandardDuration().getMillis();
     }
 
+    /**
+     * If the user can run the command, this will check if the command is null and if it is internal.
+     * If internal it will check the official guild to see if the user has the right role.
+     * <b>This does not check permissions</b>
+     * 
+     * @returns If the command is not internal or if the role has the right role to run an internal command.
+    */
+    public static boolean canRunCommand(Command command, User user) {
+        if (command == null) return false;
+        
+        if (command.getType().isInternal()) {
+            Guild g = FlareBot.getInstance().getOfficialGuild();
+            
+            if (g.getMember(user) != null)
+                return g.getMember(user).getRoles().contains(g.getRoleById(command.getType().getRoleId()));
+            else
+                return false;
+        } else
+            return true;
+    }
 }

--- a/src/main/java/stream/flarebot/flarebot/util/GeneralUtils.java
+++ b/src/main/java/stream/flarebot/flarebot/util/GeneralUtils.java
@@ -340,9 +340,8 @@ public class GeneralUtils {
             perm = perm.substring(perm.indexOf(".") + 1);
             String command = perm.split("\\.")[0];
             for (Command c : FlareBot.getInstance().getCommands()) {
-                if (c.getCommand().equalsIgnoreCase(command) && c.getType() != CommandType.SECRET) {
+                if (c.getCommand().equalsIgnoreCase(command) && !c.getType().isInternal())
                     return true;
-                }
             }
         }
         return false;


### PR DESCRIPTION
- [x] Completed PR - Has all features or fixes that it was meant to and isn't half done
- [x] Follows the style guide - Style guide found [here](https://github.com/FlareBot/FlareBot/blob/master/CONTRIBUTING.md)
- [ ] All changes have been tested

## Internal changes
* CommandType now has a long `internalRoleId` field which is used to check if a role is internal (requires some role in official guild) and the role to be checked on the server for when a user tries to use that type.
* A few changes to how permissions are handled for commands - Internal ones will now ALWAYS return null rather than just the SECRET ones.
* This fixes the issue that people could run `postupdate` and `changelog` with just normal FlareBot perms.
